### PR TITLE
Add choice of orbits to simulation

### DIFF
--- a/simulation/all_sky_signal_simulation.py
+++ b/simulation/all_sky_signal_simulation.py
@@ -26,7 +26,7 @@ import healpy as hp
 import h5py
 import os
 from datetime import datetime
-from lisaorbits import KeplerianOrbits
+from lisaorbits import KeplerianOrbits, EqualArmlengthOrbits
 from lisagwresponse import StochasticBackground
 from lisagwresponse.psd import white_generator
 from pytdi.michelson import X1, Y1, Z1, X2, Y2, Z2
@@ -56,6 +56,14 @@ if __name__ == "__main__":
         type=float,
         default=1/4,
         help="Sampling time",
+    )
+    
+    parser.add_argument(
+        "-orb",
+        "--orbits",
+        default='keplerian', 
+        choices=['keplerian','equalarm'],
+        help="Choose orbit type",
     )
     
     parser.add_argument(
@@ -97,14 +105,22 @@ if __name__ == "__main__":
     orbits_t0 = t0 - pytdi_trim * dt - orbits_trim * orbits_dt
     orbits_size = np.ceil(3600 * 24 * 365 / orbits_dt) # a year
     
+    if args.orbits == 'keplerian':
+        OrbitsGenerator = KeplerianOrbits
+    elif args.orbits == 'equalarm':
+        OrbitsGenerator = EqualArmlengthOrbits
+        
     # Generate new keplerian orbits
-    orbits = args.output_path+"/keplerian-orbits.h5"
+    orbits = args.output_path+"/"+args.orbits+"-orbits.h5"
+    print('***************************************************************************')
     if not os.path.isfile(orbits):
-        print('***************************************************************************')
-        print('**** KeplerianOrbits file not in output path folder. Generating orbit file.')
-        print('***************************************************************************')
-        orbitsobj = KeplerianOrbits()
+        print('**** Orbits file not in output path folder. Generating {orb} orbit file.'.format(orb=args.orbits))
+        orbitsobj = OrbitsGenerator()
         orbitsobj.write(orbits, dt=orbits_dt, size=orbits_size, t0=orbits_t0, mode="w")
+    else:
+        print('**** Selecting existing {orb} orbit file.'.format(orb=args.orbits))
+    print('***************************************************************************') 
+    
     # Instantiate GW signal class
     npix = hp.nside2npix(8)
     skymap = np.ones(npix) / np.sqrt(npix)
@@ -124,7 +140,7 @@ if __name__ == "__main__":
     dt_string = now.strftime("%Y-%m-%d_%Hh%M_")
     
     # Compute and save the GW response
-    gw_file = args.output_path + '/' + dt_string + 'all_sky_gw_measurements_'+str(int(fs))+'Hz.h5'
+    gw_file = args.output_path + '/' + args.orbits + dt_string + 'all_sky_gw_measurements_'+str(int(fs))+'Hz.h5'
     
     src_class.write(gw_file,
                     dt=dt, 
@@ -148,7 +164,7 @@ if __name__ == "__main__":
         y_signal = Y_data(data_signal.measurements)
         z_signal = Z_data(data_signal.measurements)
     
-        path = args.output_path + '/' + dt_string + 'all_sky_gw_tdi'+args.tdi+'_'+str(int(fs))+'Hz.h5'
+        path = args.output_path + '/' + args.orbits + dt_string + 'all_sky_gw_tdi'+args.tdi+'_'+str(int(fs))+'Hz.h5'
         hdf5 = h5py.File(path, 'a')
         hdf5.create_dataset('x', data=x_signal)
         hdf5.create_dataset('y', data=y_signal)

--- a/simulation/all_sky_signal_simulation.py
+++ b/simulation/all_sky_signal_simulation.py
@@ -137,7 +137,7 @@ if __name__ == "__main__":
     # Choose files' prefixes
     now = datetime.now()
     # dd/mm/YY H:M:S
-    dt_string = now.strftime("%Y-%m-%d_%Hh%M_")
+    dt_string = now.strftime("%Y-%m-%d_")
     
     # Compute and save the GW response
     gw_file = args.output_path + '/' + args.orbits + dt_string + 'all_sky_gw_measurements_'+str(int(fs))+'Hz.h5'

--- a/simulation/noise_simulation.py
+++ b/simulation/noise_simulation.py
@@ -39,7 +39,7 @@ import os
 import numpy as np
 from datetime import datetime
 from lisainstrument import Instrument
-from lisaorbits import KeplerianOrbits
+from lisaorbits import KeplerianOrbits, EqualArmlengthOrbits
 from pytdi.michelson import X1, Y1, Z1, X2, Y2, Z2
 from pytdi import Data
 
@@ -152,13 +152,19 @@ if __name__ == "__main__":
     orbits_t0 = t0 - pytdi_trim * dt - orbits_trim * orbits_dt
     orbits_size = np.ceil(3600 * 24 * 365 / orbits_dt) # a year
     
+    
+    if args.orbits == 'keplerian':
+        OrbitsGenerator = KeplerianOrbits
+    elif args.orbits == 'equalarm':
+        OrbitsGenerator = EqualArmlengthOrbits
+        
     # Generate new keplerian orbits
-    orbits = args.output_path+"/keplerian-orbits.h5"
+    orbits = args.output_path+"/"+args.orbits+"-orbits.h5"
     if not os.path.isfile(orbits):
         print('***************************************************************************')
-        print('**** KeplerianOrbits file not in output path folder. Generating orbit file.')
+        print('**** Orbits file not in output path folder. Generating {orb} orbit file.'.format(orb=args.orbits))
         print('***************************************************************************')
-        orbitsobj = KeplerianOrbits()
+        orbitsobj = OrbitsGenerator()
         orbitsobj.write(orbits, dt=orbits_dt, size=orbits_size, t0=orbits_t0, mode="w")
     
     # noise parameters to turn selected noises back on

--- a/simulation/noise_simulation.py
+++ b/simulation/noise_simulation.py
@@ -228,7 +228,7 @@ if __name__ == "__main__":
     now = datetime.now()
     # # dd/mm/YY H:M:S
     lockstr = 'locking_n1_12_'
-    dt_string = now.strftime("%Y-%m-%d_%Hh%M_") + args.orbits +  lockstr + 'laser_tm_oms_'
+    dt_string = now.strftime("%Y-%m-%d_") + args.orbits +  lockstr + 'laser_tm_oms_'
     
     # Simulate and save data
     instr.write(args.output_path + '/' + dt_string + 'measurements_'+str(int(fs))+'Hz.h5')

--- a/simulation/noise_simulation.py
+++ b/simulation/noise_simulation.py
@@ -160,12 +160,14 @@ if __name__ == "__main__":
         
     # Generate new keplerian orbits
     orbits = args.output_path+"/"+args.orbits+"-orbits.h5"
+    print('***************************************************************************')
     if not os.path.isfile(orbits):
-        print('***************************************************************************')
         print('**** Orbits file not in output path folder. Generating {orb} orbit file.'.format(orb=args.orbits))
-        print('***************************************************************************')
         orbitsobj = OrbitsGenerator()
         orbitsobj.write(orbits, dt=orbits_dt, size=orbits_size, t0=orbits_t0, mode="w")
+    else:
+        print('**** Selecting existing {orb} orbit file.'.format(orb=args.orbits))
+    print('***************************************************************************')        
     
     # noise parameters to turn selected noises back on
     locking='six'

--- a/simulation/noise_simulation.py
+++ b/simulation/noise_simulation.py
@@ -92,6 +92,14 @@ if __name__ == "__main__":
     )
     
     parser.add_argument(
+        "-orb",
+        "--orbits",
+        default='keplerian', 
+        choices=['keplerian','equalarm'],
+        help="Choose orbit type",
+    )
+    
+    parser.add_argument(
         "-tdi",
         "--tdi",
         default=None, 

--- a/simulation/noise_simulation.py
+++ b/simulation/noise_simulation.py
@@ -221,7 +221,7 @@ if __name__ == "__main__":
     now = datetime.now()
     # # dd/mm/YY H:M:S
     lockstr = 'locking_n1_12_'
-    dt_string = now.strftime("%Y-%m-%d_%Hh%M_") + lockstr + 'laser_tm_oms_'
+    dt_string = now.strftime("%Y-%m-%d_%Hh%M_") + args.orbits +  lockstr + 'laser_tm_oms_'
     
     # Simulate and save data
     instr.write(args.output_path + '/' + dt_string + 'measurements_'+str(int(fs))+'Hz.h5')
@@ -276,7 +276,7 @@ if __name__ == "__main__":
         instr.disable_all_noises(excluding=['laser', 'test-mass', 'oms', 'ranging', 'backlink', 'clock', 'modulation'])
         instr.simulate()
         
-        dt_string = now.strftime("%Y-%m-%d_%Hh%M_") + lockstr + 'baseline_'
+        dt_string = now.strftime("%Y-%m-%d_%Hh%M_") + args.orbits + lockstr + 'baseline_'
         
         # Simulate and save data
         instr.write(args.output_path + '/' + dt_string + 'measurements_'+str(int(fs))+'Hz.h5')

--- a/simulation/signal_simulation.py
+++ b/simulation/signal_simulation.py
@@ -137,7 +137,7 @@ if __name__ == "__main__":
     dt_string = now.strftime("%Y-%m-%d_%Hh%M_")
     
     # Compute and save the GW response
-    gw_file = args.output_path + '/' + dt_string + 'gw_measurements_'+str(int(fs))+'Hz.h5'
+    gw_file = args.output_path + '/' + args.orbits + dt_string + 'gw_measurements_'+str(int(fs))+'Hz.h5'
     src_class.write(gw_file,   
                     dt=dt, 
                     size=n_data, 
@@ -160,7 +160,7 @@ if __name__ == "__main__":
         y_signal = Y_data(data_signal.measurements)
         z_signal = Z_data(data_signal.measurements)
     
-        path = args.output_path + '/' + dt_string + 'gw_tdi'+args.tdi+'_'+str(int(fs))+'Hz.h5'
+        path = args.output_path + '/' + args.orbits + dt_string + 'gw_tdi'+args.tdi+'_'+str(int(fs))+'Hz.h5'
         hdf5 = h5py.File(path, 'a')
         hdf5.create_dataset('x', data=x_signal)
         hdf5.create_dataset('y', data=y_signal)

--- a/simulation/signal_simulation.py
+++ b/simulation/signal_simulation.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
     # Choose files' prefixes
     now = datetime.now()
     # dd/mm/YY H:M:S
-    dt_string = now.strftime("%Y-%m-%d_%Hh%M_")
+    dt_string = now.strftime("%Y-%m-%d_")
     
     # Compute and save the GW response
     gw_file = args.output_path + '/' + args.orbits + dt_string + 'gw_measurements_'+str(int(fs))+'Hz.h5'

--- a/simulation/signal_simulation.py
+++ b/simulation/signal_simulation.py
@@ -59,6 +59,14 @@ if __name__ == "__main__":
     )
     
     parser.add_argument(
+        "-orb",
+        "--orbits",
+        default='keplerian', 
+        choices=['keplerian','equalarm'],
+        help="Choose orbit type",
+    )
+    
+    parser.add_argument(
         "-tdi",
         "--tdi",
         default=None, 

--- a/simulation/signal_simulation.py
+++ b/simulation/signal_simulation.py
@@ -25,7 +25,7 @@ import numpy as np
 import h5py
 import os
 from datetime import datetime
-from lisaorbits import KeplerianOrbits
+from lisaorbits import KeplerianOrbits, EqualArmlengthOrbits
 from lisagwresponse import StochasticPointSource
 from lisagwresponse.psd import white_generator
 from pytdi.michelson import X1, Y1, Z1, X2, Y2, Z2
@@ -105,14 +105,21 @@ if __name__ == "__main__":
     orbits_t0 = t0 - pytdi_trim * dt - orbits_trim * orbits_dt
     orbits_size = np.ceil(3600 * 24 * 365 / orbits_dt) # a year
     
+    if args.orbits == 'keplerian':
+        OrbitsGenerator = KeplerianOrbits
+    elif args.orbits == 'equalarm':
+        OrbitsGenerator = EqualArmlengthOrbits
+        
     # Generate new keplerian orbits
-    orbits = args.output_path+"/keplerian-orbits.h5"
+    orbits = args.output_path+"/"+args.orbits+"-orbits.h5"
+    print('***************************************************************************')
     if not os.path.isfile(orbits):
-        print('***************************************************************************')
-        print('**** KeplerianOrbits file not in output path folder. Generating orbit file.')
-        print('***************************************************************************')
-        orbitsobj = KeplerianOrbits()
+        print('**** Orbits file not in output path folder. Generating {orb} orbit file.'.format(orb=args.orbits))
+        orbitsobj = OrbitsGenerator()
         orbitsobj.write(orbits, dt=orbits_dt, size=orbits_size, t0=orbits_t0, mode="w")
+    else:
+        print('**** Selecting existing {orb} orbit file.'.format(orb=args.orbits))
+    print('***************************************************************************') 
     
     
     # Instantiate GW signal class

--- a/simulation/simulation-scenarios.zsh
+++ b/simulation/simulation-scenarios.zsh
@@ -1,0 +1,110 @@
+#!/bin/zsh
+
+# Print date and time
+echo "Current date and time: $(date)"
+
+if [ $# -eq 0 ]
+  then
+    echo "No arguments were passed. Please specify the output path --path and the chosen orbit type --orbits."
+    exit 1
+fi
+
+# Initialize flag variables
+path_flag=false
+orbit_flag=false
+baseline_flag=false
+individual_flag=false
+combined_flag=false
+
+# Parse arguments and ensure -p and -o are provided
+while (( $# > 0 ))
+  do case $1 in
+        -p|--path)
+            path_flag=true
+            [[ -z "$2" || "$2" =~ ^- ]] && { echo "Error: --path requires a value"; exit 1; }
+            path="$2"
+            shift 2
+            ;;
+        -o|--orbits)
+            orbit_flag=true
+            [[ -z "$2" || "$2" =~ ^- ]] && { echo "Error: --orbits requires a value"; exit 1; }
+            orbits="$2"
+            shift 2
+            ;;
+        -b|--baseline)
+            baseline_flag=true
+            shift 1
+            ;;
+        -i|--individual)
+            individual_flag=true
+            shift 1
+            ;;
+        -c|--combined)
+            combined_flag=true
+            shift 1
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Check if both -p and -o are present
+if [[ "$path_flag" = false || "$orbit_flag" = false ]]
+  then
+    echo "Error: Both -p and -o arguments are required."
+    exit 1
+fi
+
+# Check if both -p and -o are present
+if [[ "$orbits" = "equalarm" ]]
+  then
+    echo "Set TDI to generation 1."
+    tdiflag = 1
+elif [[ "$orbits" = "keplerian" ]]
+  then
+    echo "Set TDI to generation 2."
+    tdiflag = 2
+else
+    echo "Orbit type is not valid, choose between equalarm or keplerian"
+    exit 1
+fi
+
+
+echo "Start simulation"
+if [[ "$baseline_flag" = true || "$individual_flag" = true || "$combined_flag" = true ]]
+  then
+    if [[ "$baseline_flag" = true && "$individual_flag" = true && "$combined_flag" = true ]]
+      then 
+        echo "Simulation with $orbits orbits, baseline noises, all individual noises + combined noises"
+        # python simulation/noise_simulation.py $path --orbits $orbits --tdi $tdi_flag --baseline --individual --combined
+    elif [[ "$baseline_flag" = true && "$individual_flag" = true ]]
+      then
+        echo "Action for -a and -b"
+        echo "Simulation with $orbits orbits, baseline noises, all individual noises, no combined noises"
+    elif [[ "$baseline_flag" = true && "$combined_flag" = true ]]
+      then
+        echo "Action for -a and -c"
+        echo "Simulation with $orbits orbits, baseline noises, no individual noises, yes combined noises"
+    elif [[ "$individual_flag" = true && "$combined_flag" = true ]]
+      then
+        echo "Action for -b and -c"
+        echo "Simulation with $orbits orbits, only lto, yes individual noises, yes combined noises"
+    elif [[ "$baseline_flag" = true ]]
+      then
+        echo "Action for -a"
+        echo "Simulation with $orbits orbits, baseline noises, no individual noises, no combined noises"
+    elif [[ "$individual_flag" = true ]]
+      then
+        echo "Action for -b"
+        echo "Simulation with $orbits orbits, only lto, yes individual noises, no combined noises"
+    elif [[ "$combined_flag" = true ]]
+      then
+        echo "Action for -c"
+        echo "Simulation with $orbits orbits, only lto, no individual noises, yes combined noises"
+    fi
+else
+    echo "No optional flags were specified."
+    echo "Simulation with $orbits orbits, only lto, no individual noise, no combined noises"
+fi


### PR DESCRIPTION
- Adding choice of orbits to simulation scripts
    - script checks if there is an orbit file in the simulation folder and creates one otherwise
    - REMEMBER TO POINT TO THE NEW ORBIT FILE in the simulations folder
- renaming simulation files to `yyyy-mm-dd` convention

Run simulations via:
```python
python simulation/noise_simulation.py $path-to-sim-folder --orbits equalarm --tdi 2
```
or
```python
python simulation/noise_simulation.py $path-to-sim-folder --orbits keplerian --tdi 2
```