### PR TITLE
Close 28-simulation-scenarios

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
                           'h5py', 
                           'scikit-learn', 
                           'lisainstrument>=1.8',
+                          'lisaorbits'
                           'lisagwresponse',
                           'pytdi'],
         # needs to be installed along with your package. Eg: 'caer'

--- a/simulation/all_sky_signal_simulation.py
+++ b/simulation/all_sky_signal_simulation.py
@@ -137,10 +137,10 @@ if __name__ == "__main__":
     # Choose files' prefixes
     now = datetime.now()
     # dd/mm/YY H:M:S
-    dt_string = now.strftime("%Y-%m-%d_")
+    dt_string = now.strftime("%Y-%m-%d_") + args.orbits + '_'
     
     # Compute and save the GW response
-    gw_file = args.output_path + '/' + args.orbits + dt_string + 'all_sky_gw_measurements_'+str(int(fs))+'Hz.h5'
+    gw_file = args.output_path + '/' + dt_string + 'all_sky_gw_measurements_'+str(int(fs))+'Hz.h5'
     
     src_class.write(gw_file,
                     dt=dt, 
@@ -164,7 +164,7 @@ if __name__ == "__main__":
         y_signal = Y_data(data_signal.measurements)
         z_signal = Z_data(data_signal.measurements)
     
-        path = args.output_path + '/' + args.orbits + dt_string + 'all_sky_gw_tdi'+args.tdi+'_'+str(int(fs))+'Hz.h5'
+        path = args.output_path + '/' + dt_string + 'all_sky_gw_tdi'+args.tdi+'_'+str(int(fs))+'Hz.h5'
         hdf5 = h5py.File(path, 'a')
         hdf5.create_dataset('x', data=x_signal)
         hdf5.create_dataset('y', data=y_signal)

--- a/simulation/all_sky_signal_simulation.py
+++ b/simulation/all_sky_signal_simulation.py
@@ -141,7 +141,10 @@ if __name__ == "__main__":
     
     # Compute and save the GW response
     gw_file = args.output_path + '/' + dt_string + 'all_sky_gw_measurements_'+str(int(fs))+'Hz.h5'
-    
+    try:
+        os.remove(gw_file)
+    except FileNotFoundError:
+        pass
     src_class.write(gw_file,
                     dt=dt, 
                     size=n_data, 
@@ -165,7 +168,11 @@ if __name__ == "__main__":
         z_signal = Z_data(data_signal.measurements)
     
         path = args.output_path + '/' + dt_string + 'all_sky_gw_tdi'+args.tdi+'_'+str(int(fs))+'Hz.h5'
-        hdf5 = h5py.File(path, 'a')
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        hdf5 = h5py.File(path, 'w')
         hdf5.create_dataset('x', data=x_signal)
         hdf5.create_dataset('y', data=y_signal)
         hdf5.create_dataset('z', data=z_signal)

--- a/simulation/noise_simulation.py
+++ b/simulation/noise_simulation.py
@@ -228,6 +228,7 @@ if __name__ == "__main__":
     now = datetime.now()
     # # dd/mm/YY H:M:S
     lockstr = '_locking_'+locking+'_'
+    
     dt_string = now.strftime("%Y-%m-%d_") + args.orbits  +  lockstr + 'laser_tm_oms_'
     
     # Simulate and save data

--- a/simulation/noise_simulation.py
+++ b/simulation/noise_simulation.py
@@ -186,6 +186,9 @@ if __name__ == "__main__":
     
     # noise parameters to turn selected noises back on
     locking=args.locking
+    print("*************************************************")
+    print("Using {locking} locking configuration".format(locking=locking))
+    print("*************************************************")
     # default parameters are commented here for reference
     # oms_asds=(6.35e-12, 1.25e-11, 1.42e-12, 3.38e-12, 3.32e-12, 7.90e-12)        
     # tm_asds=2.4E-15
@@ -246,7 +249,9 @@ if __name__ == "__main__":
     
     if args.tdi:
         data_noise = Data.from_instrument(instr)
-        
+        print("*************************************************")
+        print("Using TDI {tdi}".format(tdi=args.tdi))
+        print("*************************************************")
         if args.tdi == '2':
             X, Y, Z = X2, Y2, Z2
         else:
@@ -330,7 +335,7 @@ if __name__ == "__main__":
         instr.write(args.output_path + '/' + dt_string + 'noise_sec_'+str(int(fs))+'Hz.h5')
     
     if args.individual:
-        print("Saving individual noise contribution")
+        print("***** Saving individual noise contribution")
         
         noises = ['laser', 'test-mass', 'oms']
         
@@ -368,11 +373,13 @@ if __name__ == "__main__":
                 instr.write(args.output_path + '/' + dt_string + 'noise_'+n+'_'+str(int(fs))+'Hz.h5')
             
         if args.combined:
-            print("Saving combined noise contribution")
+            print("***** Saving combined noise contribution")
             
             noises = ['test-mass', 'oms']
             
             for n in noises:
+                print("***** Simulate laser + {n}".format(n=n))
+
                 # Instantiate LISA instrument
                 instr = Instrument(seed=simseed,
                                    size=n_data,
@@ -389,6 +396,7 @@ if __name__ == "__main__":
             if args.baseline:
                 noises = ['ranging', 'backlink', 'clock', 'modulation']
                 for n in noises:
+                    print("***** Simulate LTO + {n}".format(n=n))
                     # Instantiate LISA instrument
                     instr = Instrument(seed=simseed,
                                        size=n_data,

--- a/simulation/noise_simulation.py
+++ b/simulation/noise_simulation.py
@@ -227,8 +227,8 @@ if __name__ == "__main__":
     # datetime object containing current date and time
     now = datetime.now()
     # # dd/mm/YY H:M:S
-    lockstr = 'locking_n1_12_'
-    dt_string = now.strftime("%Y-%m-%d_") + args.orbits +  lockstr + 'laser_tm_oms_'
+    lockstr = '_locking_'+locking+'_'
+    dt_string = now.strftime("%Y-%m-%d_") + args.orbits  +  lockstr + 'laser_tm_oms_'
     
     # Simulate and save data
     instr.write(args.output_path + '/' + dt_string + 'measurements_'+str(int(fs))+'Hz.h5')
@@ -283,7 +283,7 @@ if __name__ == "__main__":
         instr.disable_all_noises(excluding=['laser', 'test-mass', 'oms', 'ranging', 'backlink', 'clock', 'modulation'])
         instr.simulate()
         
-        dt_string = now.strftime("%Y-%m-%d_%Hh%M_") + args.orbits + lockstr + 'baseline_'
+        dt_string = now.strftime("%Y-%m-%d_") + args.orbits + lockstr + 'baseline_'
         
         # Simulate and save data
         instr.write(args.output_path + '/' + dt_string + 'measurements_'+str(int(fs))+'Hz.h5')

--- a/simulation/noise_simulation.py
+++ b/simulation/noise_simulation.py
@@ -242,8 +242,14 @@ if __name__ == "__main__":
     
     dt_string = now.strftime("%Y-%m-%d_") + args.orbits  +  lockstr + 'laser_tm_oms_'
     
+    writepath = args.output_path + '/' + dt_string + 'measurements_'+str(int(fs))+'Hz.h5'
     # Simulate and save data
-    instr.write(args.output_path + '/' + dt_string + 'measurements_'+str(int(fs))+'Hz.h5')
+    # check if file exists and delete it otherwise
+    try:
+        os.remove(writepath)
+    except FileNotFoundError:
+        pass
+    instr.write(writepath)
     
     # Get the single-link outputs and delays
     
@@ -266,7 +272,11 @@ if __name__ == "__main__":
         z_noise = Z_data(data_noise.measurements)
     
         path = args.output_path + '/' + dt_string + 'noise_tdi'+args.tdi+'_'+str(int(fs))+'Hz.h5'
-        hdf5 = h5py.File(path, 'a')
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        hdf5 = h5py.File(path, 'w')
         hdf5.create_dataset('x', data=x_noise)
         hdf5.create_dataset('y', data=y_noise)
         hdf5.create_dataset('z', data=z_noise)
@@ -278,7 +288,12 @@ if __name__ == "__main__":
     instr.disable_all_noises(excluding=['test-mass', 'oms'])
     instr.simulate()
     # Store secondary noises
-    instr.write(args.output_path + '/' + dt_string + 'noise_sec_'+str(int(fs))+'Hz.h5')
+    writepath = args.output_path + '/' + dt_string + 'noise_sec_'+str(int(fs))+'Hz.h5'
+    try:
+        os.remove(writepath)
+    except FileNotFoundError:
+        pass
+    instr.write(writepath)
     
     if args.baseline:
         # Instantiate LISA instrument
@@ -300,7 +315,12 @@ if __name__ == "__main__":
         dt_string = now.strftime("%Y-%m-%d_") + args.orbits + lockstr + 'baseline_'
         
         # Simulate and save data
-        instr.write(args.output_path + '/' + dt_string + 'measurements_'+str(int(fs))+'Hz.h5')
+        writepath = args.output_path + '/' + dt_string + 'measurements_' + str(int(fs)) + 'Hz.h5'
+        try:
+            os.remove(writepath)
+        except FileNotFoundError:
+            pass
+        instr.write(writepath)
         
         # Get the single-link outputs and delays
         if args.tdi:
@@ -320,7 +340,11 @@ if __name__ == "__main__":
             z_noise = Z_data(data_noise.measurements)
         
             path = args.output_path + '/' + dt_string + 'noise_tdi'+args.tdi+'_'+str(int(fs))+'Hz.h5'
-            hdf5 = h5py.File(path, 'a')
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+            hdf5 = h5py.File(path, 'w')
             hdf5.create_dataset('x', data=x_noise)
             hdf5.create_dataset('y', data=y_noise)
             hdf5.create_dataset('z', data=z_noise)
@@ -332,7 +356,12 @@ if __name__ == "__main__":
         instr.disable_all_noises(excluding=['test-mass', 'oms', 'ranging', 'backlink', 'clock', 'modulation'])
         instr.simulate()
         # Store secondary noises
-        instr.write(args.output_path + '/' + dt_string + 'noise_sec_'+str(int(fs))+'Hz.h5')
+        writepath=args.output_path + '/' + dt_string + 'noise_sec_'+str(int(fs))+'Hz.h5'
+        try:
+            os.remove(writepath)
+        except FileNotFoundError:
+            pass
+        instr.write(writepath)
     
     if args.individual:
         print("***** Saving individual noise contribution")
@@ -351,7 +380,12 @@ if __name__ == "__main__":
                     
             instr.disable_all_noises(excluding=n) 
             instr.simulate()
-            instr.write(args.output_path + '/' + dt_string + 'noise_'+n+'_'+str(int(fs))+'Hz.h5')
+            writepath=args.output_path + '/' + dt_string + 'noise_'+n+'_'+str(int(fs))+'Hz.h5'
+            try:
+                os.remove(writepath)
+            except FileNotFoundError:
+                pass
+            instr.write(writepath)
        
         if args.baseline:
             noises = ['ranging', 'backlink', 'clock', 'modulation']
@@ -370,7 +404,12 @@ if __name__ == "__main__":
                         
                 instr.disable_all_noises(excluding=n) 
                 instr.simulate()
-                instr.write(args.output_path + '/' + dt_string + 'noise_'+n+'_'+str(int(fs))+'Hz.h5')
+                writepath=args.output_path + '/' + dt_string + 'noise_'+n+'_'+str(int(fs))+'Hz.h5'
+                try:
+                    os.remove(writepath)
+                except FileNotFoundError:
+                    pass
+                instr.write(writepath)
             
         if args.combined:
             print("***** Saving combined noise contribution")
@@ -391,7 +430,12 @@ if __name__ == "__main__":
                         
                 instr.disable_all_noises(excluding=["laser", n]) 
                 instr.simulate()
-                instr.write(args.output_path + '/' + dt_string + 'noise_'+n+'_'+str(int(fs))+'Hz.h5')
+                writepath=args.output_path + '/' + dt_string + 'noise_'+n+'_'+str(int(fs))+'Hz.h5'
+                try:
+                    os.remove(writepath)
+                except FileNotFoundError:
+                    pass
+                instr.write(writepath)
            
             if args.baseline:
                 noises = ['ranging', 'backlink', 'clock', 'modulation']
@@ -411,7 +455,12 @@ if __name__ == "__main__":
                             
                     instr.disable_all_noises(excluding=['laser', 'test-mass', 'oms', n]) 
                     instr.simulate()
-                    instr.write(args.output_path + '/' + dt_string + 'noise_'+n+'_'+str(int(fs))+'Hz.h5')
+                    writepath=args.output_path + '/' + dt_string + 'noise_'+n+'_'+str(int(fs))+'Hz.h5'
+                    try:
+                        os.remove(writepath)
+                    except FileNotFoundError:
+                        pass
+                    instr.write(writepath)
                 
             
 

--- a/simulation/noise_simulation.py
+++ b/simulation/noise_simulation.py
@@ -380,7 +380,7 @@ if __name__ == "__main__":
                     
             instr.disable_all_noises(excluding=n) 
             instr.simulate()
-            writepath=args.output_path + '/' + dt_string + 'noise_'+n+'_'+str(int(fs))+'Hz.h5'
+            writepath=args.output_path + '/' + dt_string + 'noise_individual_'+n+'_'+str(int(fs))+'Hz.h5'
             try:
                 os.remove(writepath)
             except FileNotFoundError:
@@ -404,7 +404,7 @@ if __name__ == "__main__":
                         
                 instr.disable_all_noises(excluding=n) 
                 instr.simulate()
-                writepath=args.output_path + '/' + dt_string + 'noise_'+n+'_'+str(int(fs))+'Hz.h5'
+                writepath=args.output_path + '/' + dt_string + 'noise_individual_'+n+'_'+str(int(fs))+'Hz.h5'
                 try:
                     os.remove(writepath)
                 except FileNotFoundError:
@@ -430,7 +430,7 @@ if __name__ == "__main__":
                         
                 instr.disable_all_noises(excluding=["laser", n]) 
                 instr.simulate()
-                writepath=args.output_path + '/' + dt_string + 'noise_'+n+'_'+str(int(fs))+'Hz.h5'
+                writepath=args.output_path + '/' + dt_string + 'noise_combined_laser_'+n+'_'+str(int(fs))+'Hz.h5'
                 try:
                     os.remove(writepath)
                 except FileNotFoundError:
@@ -455,7 +455,7 @@ if __name__ == "__main__":
                             
                     instr.disable_all_noises(excluding=['laser', 'test-mass', 'oms', n]) 
                     instr.simulate()
-                    writepath=args.output_path + '/' + dt_string + 'noise_'+n+'_'+str(int(fs))+'Hz.h5'
+                    writepath=args.output_path + '/' + dt_string + 'noise_combined_lto_'+n+'_'+str(int(fs))+'Hz.h5'
                     try:
                         os.remove(writepath)
                     except FileNotFoundError:

--- a/simulation/noise_simulation.py
+++ b/simulation/noise_simulation.py
@@ -100,6 +100,14 @@ if __name__ == "__main__":
     )
     
     parser.add_argument(
+        "-l",
+        "--locking",
+        default='N1-12', 
+        choices=['six','N1-12'],
+        help="Choose locking configuration",
+    )
+    
+    parser.add_argument(
         "-tdi",
         "--tdi",
         default=None, 
@@ -177,7 +185,7 @@ if __name__ == "__main__":
     print('***************************************************************************')        
     
     # noise parameters to turn selected noises back on
-    locking='six'
+    locking=args.locking
     # default parameters are commented here for reference
     # oms_asds=(6.35e-12, 1.25e-11, 1.42e-12, 3.38e-12, 3.32e-12, 7.90e-12)        
     # tm_asds=2.4E-15
@@ -190,7 +198,7 @@ if __name__ == "__main__":
         print("*************************************************")
         print("Using LISA-LCST-SGS-RP-006 baseline configuration")
         print("*************************************************")
-        locking='N1-12' # default configuration used in LISA-LCST-SGS-RP-006
+        # locking='N1-12' # default configuration used in LISA-LCST-SGS-RP-006
         # default parameters are commented here for reference
         ranging_asds=3e-9
         ranging_b = [ranging_asds * x for x in (2, -1, -1.5, 3, 0.5, 0.75)]

--- a/simulation/signal_simulation.py
+++ b/simulation/signal_simulation.py
@@ -138,6 +138,10 @@ if __name__ == "__main__":
     
     # Compute and save the GW response
     gw_file = args.output_path + '/' + dt_string + 'gw_measurements_'+str(int(fs))+'Hz.h5'
+    try:
+        os.remove(gw_file)
+    except FileNotFoundError:
+        pass
     src_class.write(gw_file,   
                     dt=dt, 
                     size=n_data, 
@@ -161,7 +165,11 @@ if __name__ == "__main__":
         z_signal = Z_data(data_signal.measurements)
     
         path = args.output_path + '/' + dt_string + 'gw_tdi'+args.tdi+'_'+str(int(fs))+'Hz.h5'
-        hdf5 = h5py.File(path, 'a')
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        hdf5 = h5py.File(path, 'w')
         hdf5.create_dataset('x', data=x_signal)
         hdf5.create_dataset('y', data=y_signal)
         hdf5.create_dataset('z', data=z_signal)

--- a/simulation/signal_simulation.py
+++ b/simulation/signal_simulation.py
@@ -134,10 +134,10 @@ if __name__ == "__main__":
     # Choose files' prefixes
     now = datetime.now()
     # dd/mm/YY H:M:S
-    dt_string = now.strftime("%Y-%m-%d_")
+    dt_string = now.strftime("%Y-%m-%d_") + args.orbits + '_'
     
     # Compute and save the GW response
-    gw_file = args.output_path + '/' + args.orbits + dt_string + 'gw_measurements_'+str(int(fs))+'Hz.h5'
+    gw_file = args.output_path + '/' + dt_string + 'gw_measurements_'+str(int(fs))+'Hz.h5'
     src_class.write(gw_file,   
                     dt=dt, 
                     size=n_data, 
@@ -160,7 +160,7 @@ if __name__ == "__main__":
         y_signal = Y_data(data_signal.measurements)
         z_signal = Z_data(data_signal.measurements)
     
-        path = args.output_path + '/' + args.orbits + dt_string + 'gw_tdi'+args.tdi+'_'+str(int(fs))+'Hz.h5'
+        path = args.output_path + '/' + dt_string + 'gw_tdi'+args.tdi+'_'+str(int(fs))+'Hz.h5'
         hdf5 = h5py.File(path, 'a')
         hdf5.create_dataset('x', data=x_signal)
         hdf5.create_dataset('y', data=y_signal)

--- a/simulation/simulation-scenarios.py
+++ b/simulation/simulation-scenarios.py
@@ -28,3 +28,24 @@ os.system('python simulation/noise_simulation.py ../../../research/GSFC/pci-inre
 # %% keplerian
 os.system('python simulation/noise_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits keplerian --tdi 2 --locking "six" --baseline --individual --combined')
 
+
+# %% Signal simulation
+# %% equalarm tdi 1
+os.system('python simulation/signal_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits equalarm --tdi 1')
+
+# %% equalarm tdi 2
+os.system('python simulation/signal_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits equalarm --tdi 2')
+
+# %% keplerian
+os.system('python simulation/signal_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits keplerian --tdi 2')
+
+# %% All sky simulation
+
+# %% equalarm tdi 1
+os.system('python simulation/all_sky_signal_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits equalarm --tdi 1')
+
+# %% equalarm tdi 2
+os.system('python simulation/all_sky_signal_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits equalarm --tdi 2')
+
+# %% keplerian
+os.system('python simulation/all_sky_signal_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits keplerian --tdi 2')

--- a/simulation/simulation-scenarios.py
+++ b/simulation/simulation-scenarios.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Apr  4 15:39:05 2025
+
+@author: ecastel2
+"""
+
+import os
+
+# %% LOCKING N1-12 default
+# %% equalarm tdi1
+os.system('python simulation/noise_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits equalarm --tdi 1 --locking "N1-12" --individual --combined')
+
+# %% equalarm tdi2
+os.system('python simulation/noise_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits equalarm --tdi 2 --locking "N1-12" --individual --combined')
+
+# %% keplerian
+os.system('python simulation/noise_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits keplerian --tdi 2 --locking "N1-12" --baseline --individual --combined')
+
+# %% LOCKING 'six'
+# %% equalarm tdi1
+os.system('python simulation/noise_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits equalarm --tdi 1 --locking "six" --individual --combined')
+
+# %% equalarm tdi2
+os.system('python simulation/noise_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits equalarm --tdi 2 --locking "six" --individual --combined')
+
+# %% keplerian
+os.system('python simulation/noise_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits keplerian --tdi 2 --locking "six" --baseline --individual --combined')
+

--- a/simulation/simulation-scenarios.zsh
+++ b/simulation/simulation-scenarios.zsh
@@ -61,11 +61,11 @@ fi
 if [[ "$orbits" = "equalarm" ]]
   then
     echo "Set TDI to generation 1."
-    tdiflag = 1
+    tdiflag=1
 elif [[ "$orbits" = "keplerian" ]]
   then
     echo "Set TDI to generation 2."
-    tdiflag = 2
+    tdiflag=2
 else
     echo "Orbit type is not valid, choose between equalarm or keplerian"
     exit 1

--- a/simulation/simulation-scenarios.zsh
+++ b/simulation/simulation-scenarios.zsh
@@ -12,9 +12,7 @@ fi
 # Initialize flag variables
 path_flag=false
 orbit_flag=false
-baseline_flag=false
-individual_flag=false
-combined_flag=false
+locking_flag=false
 
 # Parse arguments and ensure -p and -o are provided
 while (( $# > 0 ))
@@ -31,17 +29,11 @@ while (( $# > 0 ))
             orbits="$2"
             shift 2
             ;;
-        -b|--baseline)
-            baseline_flag=true
-            shift 1
-            ;;
-        -i|--individual)
-            individual_flag=true
-            shift 1
-            ;;
-        -c|--combined)
-            combined_flag=true
-            shift 1
+        -l|--locking)
+            locking_flag=true
+            [[ -z "$2" || "$2" =~ ^- ]] && { echo "Error: --locking requires a value"; exit 1; }
+            locking="$2"
+            shift 2
             ;;
         *)
             echo "Unknown argument: $1"
@@ -51,60 +43,26 @@ while (( $# > 0 ))
 done
 
 # Check if both -p and -o are present
-if [[ "$path_flag" = false || "$orbit_flag" = false ]]
+if [[ "$path_flag" = false || "$orbit_flag" = false || "$locking_flag" = false ]]
   then
-    echo "Error: Both -p and -o arguments are required."
+    echo "Error: All -p, -o and -l arguments are required."
     exit 1
 fi
-
+echo "Start simulation"
 # Check if both -p and -o are present
 if [[ "$orbits" = "equalarm" ]]
   then
     echo "Set TDI to generation 1."
     tdiflag=1
+    echo "Simulation with $orbits orbits, LTO noise, TM and OMS individual noises + combined noises"
+    python simulation/noise_simulation.py $path --orbits $orbits --tdi $tdi_flag --locking $locking --individual --combined
 elif [[ "$orbits" = "keplerian" ]]
   then
     echo "Set TDI to generation 2."
-    tdiflag=2
+        tdiflag=2
+    echo "Simulation with $orbits orbits, baseline noise, all individual noises + combined noises"
+    python simulation/noise_simulation.py $path --orbits $orbits --tdi $tdi_flag --locking $locking --baseline --individual --combined
 else
     echo "Orbit type is not valid, choose between equalarm or keplerian"
     exit 1
-fi
-
-
-echo "Start simulation"
-if [[ "$baseline_flag" = true || "$individual_flag" = true || "$combined_flag" = true ]]
-  then
-    if [[ "$baseline_flag" = true && "$individual_flag" = true && "$combined_flag" = true ]]
-      then 
-        echo "Simulation with $orbits orbits, baseline noises, all individual noises + combined noises"
-        # python simulation/noise_simulation.py $path --orbits $orbits --tdi $tdi_flag --baseline --individual --combined
-    elif [[ "$baseline_flag" = true && "$individual_flag" = true ]]
-      then
-        echo "Action for -a and -b"
-        echo "Simulation with $orbits orbits, baseline noises, all individual noises, no combined noises"
-    elif [[ "$baseline_flag" = true && "$combined_flag" = true ]]
-      then
-        echo "Action for -a and -c"
-        echo "Simulation with $orbits orbits, baseline noises, no individual noises, yes combined noises"
-    elif [[ "$individual_flag" = true && "$combined_flag" = true ]]
-      then
-        echo "Action for -b and -c"
-        echo "Simulation with $orbits orbits, only lto, yes individual noises, yes combined noises"
-    elif [[ "$baseline_flag" = true ]]
-      then
-        echo "Action for -a"
-        echo "Simulation with $orbits orbits, baseline noises, no individual noises, no combined noises"
-    elif [[ "$individual_flag" = true ]]
-      then
-        echo "Action for -b"
-        echo "Simulation with $orbits orbits, only lto, yes individual noises, no combined noises"
-    elif [[ "$combined_flag" = true ]]
-      then
-        echo "Action for -c"
-        echo "Simulation with $orbits orbits, only lto, no individual noises, yes combined noises"
-    fi
-else
-    echo "No optional flags were specified."
-    echo "Simulation with $orbits orbits, only lto, no individual noise, no combined noises"
 fi

--- a/simulation/simulation_consolidation.py
+++ b/simulation/simulation_consolidation.py
@@ -864,3 +864,6 @@ ax.set_ylabel(r'$S_\text{TDI}(f)$')
 
 # %%
 # pp.close()
+
+
+


### PR DESCRIPTION
Amended simulation scripts with following changes
- specify orbit type with flag `--orbits` and choice between `equalarm` and `keplerian`
- specify locking with flag `--locking` and choice between `'N1-12'` and `'six'`
- save all individual noise contributions with flag `--individual`
- save combined noises with flag `--combined`

E.g. a laser-tm-oms simulation with equal armlength orbits and default locking `'N1-12'` configuration can be called via:
```python
python simulation/noise_simulation.py ../../../research/GSFC/pci-inrep/simulations --orbits equalarm --tdi 1 --locking "N1-12" --individual --combined
```

I also added a master script to generate all the scenarios for benchmarking.